### PR TITLE
fix(webui): refuse path traversal in static file serving

### DIFF
--- a/server.py
+++ b/server.py
@@ -680,16 +680,42 @@ async def _handle_stream(proxy_id: str, prompt: str, tools: list[ToolDef] | None
 
 # ── Admin & static file serving ──────────────────────────────
 
-_WEBUI_DIR = _os.path.join(_os.path.dirname(__file__), "webui")
+_WEBUI_DIR = _os.path.realpath(_os.path.join(_os.path.dirname(__file__), "webui"))
 
 app.include_router(admin_router)
+
+
+def _safe_webui_path(rest_of_path: str) -> str | None:
+    """Resolve a path inside the webui dir, refusing traversal.
+
+    Returns the absolute file path if it points to a file under _WEBUI_DIR,
+    otherwise None. Defends against `..\\..\\.env` style requests that would
+    otherwise let unauthenticated callers read project secrets.
+    """
+    if not rest_of_path:
+        return None
+    # Reject obviously hostile inputs early.
+    if "\x00" in rest_of_path:
+        return None
+    candidate = _os.path.realpath(_os.path.join(_WEBUI_DIR, rest_of_path))
+    try:
+        common = _os.path.commonpath([candidate, _WEBUI_DIR])
+    except ValueError:
+        # Different drives on Windows raise ValueError.
+        return None
+    if common != _WEBUI_DIR:
+        return None
+    if not _os.path.isfile(candidate):
+        return None
+    return candidate
+
 
 if _os.path.isdir(_WEBUI_DIR):
     @app.get("/webui/{rest_of_path:path}")
     async def webui_spa(rest_of_path: str):
-        file_path = _os.path.join(_WEBUI_DIR, rest_of_path) if rest_of_path else _WEBUI_DIR
-        if _os.path.isfile(file_path):
-            return FileResponse(file_path)
+        safe = _safe_webui_path(rest_of_path)
+        if safe is not None:
+            return FileResponse(safe)
         index = _os.path.join(_WEBUI_DIR, "index.html")
         if _os.path.isfile(index):
             return FileResponse(index)


### PR DESCRIPTION
### Summary

The `/webui/{rest_of_path}` handler in `server.py` resolves the requested path with `os.path.join + os.path.isfile` but never validates that the resolved file actually stays inside the webui directory. Encoded traversal payloads escape the static dir and can serve project files. On a public deployment this leaks `.env` (containing `DEEPSEEK_TOKEN`, `DEEPSEEK_COOKIES`, `API_KEYS`, `DEEPSEEK_ADMIN_PASSWORD`), `data/accounts.json`, and any other readable file under the project root.

### Reproduce on `main`

```bash
# Start a server with any token / cookies in .env, then:
curl 'http://localhost:8080/webui/..%2F.env'
curl 'http://localhost:8080/webui/..%5C..%5C.env'
curl 'http://localhost:8080/webui/....%2F%2F.env'
```

These return the contents of `.env`, not the SPA index.

### Fix

Add `_safe_webui_path()` that:
1. Resolves the candidate via `os.path.realpath`
2. Verifies `commonpath([candidate, _WEBUI_DIR]) == _WEBUI_DIR`
3. Confirms the result is a regular file

If any check fails, the handler falls back to serving `index.html` (same UX as before for legitimate paths). `_WEBUI_DIR` itself is now `realpath`-resolved at module import so the comparison is symlink-stable.

### Verified

- 8 encoded traversal payloads (`..%2F.env`, `..%5C.env`, `....%2F%2F.env`, `%2E%2E%2F.env`, mixed encodings, Windows-style backslash variants) — all fall back to `index.html`, none leak anything
- FastAPI's path normalization independently rejects raw `../` payloads with 404 (defense-in-depth confirmed)
- Normal `/webui/`, `/webui/app.js`, `/webui/index.html` still return 200 with correct content

### Risk

Pure defensive change. No functional behavior changes for legitimate users; only path-escape requests differ. No new dependencies.