### PR TITLE
feat(adapter): use real-Chrome request headers + accept wrapped token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ ALLOW_UNAUTHENTICATED_API=false
 # Get these from browser DevTools -> Network -> any request to chat.deepseek.com
 # DEEPSEEK_TOKEN = "Authorization" header value after "Bearer "
 # DEEPSEEK_COOKIES = "Cookie" header value
+#
+# Note on token format: DeepSeek's localStorage stores the token as a JSON
+# wrapper like {"value":"<bare-token>","__version":"0"}, while the actual
+# network request sends only <bare-token> after "Bearer ". The adapter
+# accepts either form — paste whichever you copied and it will be unwrapped
+# automatically.
 
 # Numbered multi-account format. Env accounts are loaded on startup and are
 # read-only in the web panel; edit .env and restart the service to change them.

--- a/adapter.py
+++ b/adapter.py
@@ -88,24 +88,71 @@ class DeepSeekAdapter:
     """Adapter for DeepSeek Chat API"""
 
     def __init__(self, token: str = TOKEN, cookies: str = COOKIES):
-        self.token = token
+        self.token = self._normalize_token(token)
         self.cookies = cookies
         self._solver = None
         self._client = httpx.Client(timeout=120)
         self._msg_counters: dict[str, int] = {}
+        # Header set captured from a live Chrome 149 session against
+        # chat.deepseek.com (frontend commit 1300ef9f7, captured 2026-06-19).
+        # Names use the same casing the real browser sends.
         self._base_headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
+            "Authorization": f"Bearer {self.token}",
             "Cookie": cookies,
             "Origin": BASE_URL,
             "Referer": f"{BASE_URL}/",
-            "X-App-Version": "20241129.1",
+            "Priority": "u=1, i",
+            "Sec-Ch-Ua": (
+                '"Google Chrome";v="131", "Chromium";v="131", '
+                '"Not_A Brand";v="24"'
+            ),
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            # Application headers — values verified against the live frontend.
+            "X-App-Version": "2.0.0",
             "X-Client-Version": "2.0.0",
             "X-Client-Platform": "web",
             "X-Client-Locale": "zh_CN",
             "X-Client-Timezone-Offset": "28800",
+            "x-client-bundle-id": "com.deepseek.chat",
         }
+
+    @staticmethod
+    def _normalize_token(token: str) -> str:
+        """Accept either a bare token or DeepSeek's localStorage JSON wrapper.
+
+        DeepSeek stores its token in localStorage as
+            {"value":"<bare-token>","__version":"0"}
+        but the network layer sends only the bare value as
+            Authorization: Bearer <bare-token>
+        Users sometimes copy the localStorage form by mistake. Auto-unwrap
+        it so the adapter accepts either form.
+        """
+        if not token:
+            return token
+        s = token.strip()
+        if s.startswith("Bearer "):
+            s = s[len("Bearer "):].strip()
+        if s.startswith("{") and s.endswith("}"):
+            try:
+                obj = json.loads(s)
+                if isinstance(obj, dict) and "value" in obj and isinstance(obj["value"], str):
+                    return obj["value"]
+            except (ValueError, TypeError):
+                pass
+        return s
 
     @property
     def solver(self):


### PR DESCRIPTION
### Summary

Two related anti-detection improvements, no new dependencies. The bigger TLS-fingerprint switch is in a separate follow-up PR to keep this diff reviewable.

### 1. Header set rewrite

I captured the real `chat.deepseek.com` request headers from a live Chrome 149 session on 2026-06-19 (frontend `commit_id: 1300ef9f7`) and compared with what `adapter.py` sends today. The current set is unmistakably non-browser:

| Header | Current | Real Chrome |
|---|---|---|
| `User-Agent` | ends at `AppleWebKit/537.36` (truncated) | full `Chrome/131.0.0.0 Safari/537.36` |
| `sec-ch-ua` / `sec-ch-ua-mobile` / `sec-ch-ua-platform` | missing | required values present |
| `sec-fetch-site` / `sec-fetch-mode` / `sec-fetch-dest` | missing | `same-origin` / `cors` / `empty` |
| `accept` / `accept-encoding` / `accept-language` / `priority` | missing | sent on every request |
| `X-App-Version` | hardcoded `20241129.1` | **`2.0.0`** (live frontend value) |
| `x-client-bundle-id` | missing entirely | **`com.deepseek.chat`** (computed from a region constant in main.js) |

The hardcoded `X-App-Version: 20241129.1` is particularly damaging: any value that doesn't match the current frontend's literal is itself a fingerprint. Frontend computes the bundle id as `e === "dseek" ? "com.deepseek.chat.nov" : "com.deepseek.chat"`; default region (en/zh) gets the latter.

### 2. `_normalize_token()` helper

DeepSeek's localStorage stores the bearer in a JSON wrapper:

```json
{"value": "<bare-token>", "__version": "0"}
```

But the network layer sends only `Authorization: Bearer <bare-token>`. Users following the README copy from the request header (correct) and it works. Users copying from `DevTools → Application → Local Storage → userToken` end up with the wrapper, paste it into `.env`, and hit `40003 Authorization Failed`.

Auto-unwrap in the adapter so both forms work, and add a note in `.env.example` so the next person doesn't burn an hour debugging.

### Verified end-to-end against `chat.deepseek.com`

```
/v1/chat/completions  non-stream → 200, content matches expected, finish_reason=stop
/v1/chat/completions  stream     → 200, finish_reason=stop, [DONE] frame present
/v1/messages          non-stream → 200, stop_reason=end_turn
/v1/messages          stream     → 200, full message_start → block → delta → block_stop → message_delta → message_stop sequence
/api/v0/chat/create_pow_challenge → 200, server: CW (DeepSeek's own edge)
                                      no cf-mitigated, no x-amzn-waf-action
                                      HWWAF (the cloud WAF in front of the origin) issues a fresh HWWAFSESID session cookie
                                      = the request passed bot detection
```

### Risk

Low. No new dependencies. The Chrome major (`131`) is deliberately chosen to match the curl_cffi `chrome131` impersonation profile in the follow-up PR — bumping both together avoids a UA-vs-TLS-fingerprint contradiction. If you prefer a different Chrome major, I'm happy to bump.

### Notes

- Adding the new headers via `_base_headers` keeps them visible in tracebacks and easy to override per-account. Same model as today's code.
- `_normalize_token` is conservative: malformed JSON, JSON without `value`, or a non-dict JSON falls through unchanged so existing valid tokens are not mangled.