### PR TITLE
feat(adapter): TLS-fingerprint impersonation via curl_cffi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,25 @@ SEARCH=auto
 # Admin panel password (for /webui management interface)
 # If not set, default is "admin". Change this before exposing the service.
 DEEPSEEK_ADMIN_PASSWORD=admin
+
+# ── Anti-detection ───────────────────────────────────────────
+# TLS / JA3 impersonation profile. Passed to curl_cffi.Session.
+# Pick a profile close to a current Chrome Stable to match what real users send.
+# Values: chrome120, chrome123, chrome124, chrome131, chrome133, chrome136, ...
+# (depends on the curl_cffi version installed). chrome131 is a safe default
+# in mid-2026.
+DEEPSEEK_IMPERSONATE=chrome131
+
+# Per-account upstream proxy (optional). When set, the adapter for that
+# account routes all DeepSeek calls through this proxy. Format: protocol+
+# auth+host+port, e.g. http://user:pass@proxy.example.com:8080 or
+# socks5://127.0.0.1:1080. Strongly recommended when using multiple
+# accounts: pin each account to a stable residential exit so DeepSeek's
+# risk engine doesn't see N accounts dialing from the same IP.
+# DEEPSEEK_PROXY_1=http://127.0.0.1:7901
+# DEEPSEEK_PROXY_2=http://127.0.0.1:7902
+
+# Inter-call jitter (seconds). Sleep a small uniform-random delay before
+# each upstream call to break perfectly-timed automation patterns.
+# 0 disables jitter. Default 0.0; suggested 0.4 in production.
+DEEPSEEK_JITTER_SECS=0.0

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ ALLOW_UNAUTHENTICATED_API=false
 # Get these from browser DevTools -> Network -> any request to chat.deepseek.com
 # DEEPSEEK_TOKEN = "Authorization" header value after "Bearer "
 # DEEPSEEK_COOKIES = "Cookie" header value
+#
+# Note on token format: DeepSeek's localStorage stores the token as a JSON
+# wrapper like {"value":"<bare-token>","__version":"0"}, while the actual
+# network request sends only <bare-token> after "Bearer ". The adapter
+# accepts either form — paste whichever you copied and it will be unwrapped
+# automatically.
 
 # Numbered multi-account format. Env accounts are loaded on startup and are
 # read-only in the web panel; edit .env and restart the service to change them.

--- a/account_pool.py
+++ b/account_pool.py
@@ -67,6 +67,7 @@ class Account:
     email: str = ""
     id: str = field(default_factory=_account_id)
     source: str = "file"       # file | env
+    proxy: str = ""             # per-account upstream proxy (optional)
     created_at: int = field(default_factory=_now)
     updated_at: int = field(default_factory=_now)
     state: str = "idle"        # idle | busy | error
@@ -78,7 +79,11 @@ class Account:
     @property
     def adapter(self) -> DeepSeekAdapter:
         if self._adapter is None:
-            self._adapter = DeepSeekAdapter(token=self.token, cookies=self.cookies)
+            self._adapter = DeepSeekAdapter(
+                token=self.token,
+                cookies=self.cookies,
+                proxy=self.proxy or None,
+            )
         return self._adapter
 
     @property
@@ -169,6 +174,7 @@ class AccountPool:
             token = os.environ.get(f"DEEPSEEK_TOKEN_{i}", "").strip()
             cookies = os.environ.get(f"DEEPSEEK_COOKIES_{i}", "").strip()
             email = os.environ.get(f"DEEPSEEK_EMAIL_{i}", "").strip() or f"env-{i}"
+            proxy = os.environ.get(f"DEEPSEEK_PROXY_{i}", "").strip()
             if not token and not cookies:
                 continue
             if not token or not cookies:
@@ -179,18 +185,21 @@ class AccountPool:
                 email=email,
                 token=token,
                 cookies=cookies,
+                proxy=proxy,
                 source="env",
             ))
 
         token = os.environ.get("DEEPSEEK_TOKEN", "").strip()
         cookies = os.environ.get("DEEPSEEK_COOKIES", "").strip()
         email = os.environ.get("DEEPSEEK_EMAIL", "").strip() or "env-default"
+        proxy = os.environ.get("DEEPSEEK_PROXY", "").strip()
         if token and cookies:
             self._append_loaded(Account(
                 id="env-default",
                 email=email,
                 token=token,
                 cookies=cookies,
+                proxy=proxy,
                 source="env",
             ))
         elif token or cookies:

--- a/adapter.py
+++ b/adapter.py
@@ -1,24 +1,45 @@
 """
 DeepSeek Chat API Adapter - WASM-based PoW solving, session management, streaming
 Supports expert mode (thinking_enabled, search_enabled).
+
+Anti-detection upgrades (2026-06):
+- TLS/JA3 impersonation via curl_cffi (chrome131)
+- Header set & values captured from a real Chrome 149 + chat.deepseek.com session
+- Cookie jar auto-rotates Set-Cookie (cf_clearance / awswaf token refresh)
+- Detects 405 x-amzn-waf-action=captcha and 403/429 cf-mitigated=challenge
 """
 import json
 import os
 import time
 import struct
 import base64
+import random
 import threading
-import httpx
+from pathlib import Path
 from dotenv import load_dotenv
 from wasmtime import Store, Module, Instance
+
+try:
+    from curl_cffi import requests as cffi_requests
+except ImportError as e:
+    raise SystemExit(
+        "curl_cffi is required for TLS fingerprint impersonation.\n"
+        "Run: pip install -r requirements.txt"
+    ) from e
 
 load_dotenv()
 
 COOKIES = os.environ.get("DEEPSEEK_COOKIES", "")
 BASE_URL = "https://chat.deepseek.com"
 TOKEN = os.environ.get("DEEPSEEK_TOKEN", "")
+IMPERSONATE = os.environ.get("DEEPSEEK_IMPERSONATE", "chrome131")
+try:
+    JITTER_SECS = max(0.0, float(os.environ.get("DEEPSEEK_JITTER_SECS", "0") or 0))
+except ValueError:
+    JITTER_SECS = 0.0
 
-with open("sha3_wasm_bg.wasm", "rb") as f:
+_WASM_PATH = Path(__file__).resolve().parent / "sha3_wasm_bg.wasm"
+with open(_WASM_PATH, "rb") as f:
     _WASM_BYTES = f.read()
 
 
@@ -28,6 +49,15 @@ class WASMError(Exception):
 
 class PoWError(Exception):
     pass
+
+
+class WAFChallengeError(Exception):
+    """Raised when AWS WAF or Cloudflare returns a challenge response."""
+    def __init__(self, kind: str, status: int, body: str = ""):
+        super().__init__(f"{kind} challenge ({status}): {body[:200]}")
+        self.kind = kind
+        self.status = status
+        self.body = body
 
 
 class _WASMSolver:
@@ -87,40 +117,69 @@ class _WASMSolver:
 class DeepSeekAdapter:
     """Adapter for DeepSeek Chat API"""
 
-    def __init__(self, token: str = TOKEN, cookies: str = COOKIES):
+    # Captured 2026-06-19 from a live Chrome 149 session on chat.deepseek.com.
+    # We DOWNGRADE the UA string to Chrome 131 to match what curl_cffi's
+    # `chrome131` impersonation profile actually negotiates at the TLS layer:
+    # the JA3/JA4 fingerprint comes from a Chrome 131 build, so a Chrome 149
+    # UA on a Chrome 131 ClientHello is itself a fingerprint mismatch. Bump
+    # both together when curl_cffi adds newer chrome profiles.
+    _DEFAULT_UA = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    )
+    _DEFAULT_SEC_CH_UA = (
+        '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"'
+    )
+
+    def __init__(self, token: str = TOKEN, cookies: str = COOKIES,
+                 impersonate: str = IMPERSONATE, proxy: str | None = None):
         self.token = self._normalize_token(token)
         self.cookies = cookies
+        self.impersonate = impersonate
         self._solver = None
-        self._client = httpx.Client(timeout=120)
+        # curl_cffi.Session keeps a cookie jar that auto-merges Set-Cookie,
+        # so cf_clearance / AWS WAF tokens stay fresh across calls.
+        self._client = cffi_requests.Session(
+            impersonate=impersonate,
+            timeout=120,
+            proxies={"all": proxy} if proxy else None,
+        )
+        # Seed jar from the user-supplied cookie blob (one-shot import only;
+        # afterwards the jar is the source of truth).
+        if cookies:
+            for part in cookies.split(";"):
+                part = part.strip()
+                if not part or "=" not in part:
+                    continue
+                name, value = part.split("=", 1)
+                try:
+                    self._client.cookies.set(
+                        name.strip(), value.strip(), domain=".deepseek.com"
+                    )
+                except Exception:
+                    pass
+
         self._msg_counters: dict[str, int] = {}
-        # Header set captured from a live Chrome 149 session against
-        # chat.deepseek.com (frontend commit 1300ef9f7, captured 2026-06-19).
+        # Header set captured from a live browser fetch().
         # Names use the same casing the real browser sends.
         self._base_headers = {
-            "User-Agent": (
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/131.0.0.0 Safari/537.36"
-            ),
+            "User-Agent": self._DEFAULT_UA,
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate, br, zstd",
             "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.token}",
-            "Cookie": cookies,
             "Origin": BASE_URL,
             "Referer": f"{BASE_URL}/",
             "Priority": "u=1, i",
-            "Sec-Ch-Ua": (
-                '"Google Chrome";v="131", "Chromium";v="131", '
-                '"Not_A Brand";v="24"'
-            ),
+            "Sec-Ch-Ua": self._DEFAULT_SEC_CH_UA,
             "Sec-Ch-Ua-Mobile": "?0",
             "Sec-Ch-Ua-Platform": '"Windows"',
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
             "Sec-Fetch-Site": "same-origin",
-            # Application headers — values verified against the live frontend.
+            # DeepSeek-specific application headers (current as of 2026-06-19).
             "X-App-Version": "2.0.0",
             "X-Client-Version": "2.0.0",
             "X-Client-Platform": "web",
@@ -135,10 +194,9 @@ class DeepSeekAdapter:
 
         DeepSeek stores its token in localStorage as
             {"value":"<bare-token>","__version":"0"}
-        but the network layer sends only the bare value as
-            Authorization: Bearer <bare-token>
-        Users sometimes copy the localStorage form by mistake. Auto-unwrap
-        it so the adapter accepts either form.
+        but the network layer sends only the bare value as `Authorization:
+        Bearer <bare-token>`. Users sometimes copy the localStorage form by
+        mistake. Auto-unwrap it so the adapter accepts either form.
         """
         if not token:
             return token
@@ -154,6 +212,20 @@ class DeepSeekAdapter:
                 pass
         return s
 
+    @staticmethod
+    def _detect_waf_challenge(status: int, headers) -> str | None:
+        """Return the challenge kind if the response is a WAF/CDN challenge."""
+        get = headers.get if hasattr(headers, "get") else lambda k, d=None: dict(headers).get(k, d)
+        waf_action = (get("x-amzn-waf-action") or "").lower()
+        cf_mitigated = (get("cf-mitigated") or "").lower()
+        if status == 405 and waf_action == "captcha":
+            return "aws-waf-captcha"
+        if status == 202 and waf_action == "challenge":
+            return "aws-waf-challenge"
+        if status in (403, 429) and cf_mitigated == "challenge":
+            return "cloudflare-challenge"
+        return None
+
     @property
     def solver(self):
         if self._solver is None:
@@ -166,6 +238,9 @@ class DeepSeekAdapter:
             json={"target_path": target_path},
             headers=self._base_headers,
         )
+        kind = self._detect_waf_challenge(resp.status_code, resp.headers)
+        if kind:
+            raise WAFChallengeError(kind, resp.status_code, resp.text)
         resp.raise_for_status()
         data = resp.json()
         try:
@@ -193,6 +268,8 @@ class DeepSeekAdapter:
         return base64.b64encode(raw.encode()).decode()
 
     def _pow_headers(self, target_path: str = "/api/v0/chat/completion"):
+        if JITTER_SECS > 0:
+            time.sleep(random.uniform(0, JITTER_SECS))
         c = self._get_challenge(target_path)
         pow_h = self._solve(c)
         return {**self._base_headers, "X-DS-PoW-Response": pow_h}
@@ -205,6 +282,9 @@ class DeepSeekAdapter:
             json={"target_path": "/api/v0/chat/completion"},
             headers=headers,
         )
+        kind = self._detect_waf_challenge(resp.status_code, resp.headers)
+        if kind:
+            raise WAFChallengeError(kind, resp.status_code, resp.text)
         resp.raise_for_status()
         data = resp.json()
         if data.get("code") != 0:
@@ -255,6 +335,9 @@ class DeepSeekAdapter:
             json=body,
             headers=headers,
         )
+        kind = self._detect_waf_challenge(resp.status_code, resp.headers)
+        if kind:
+            raise WAFChallengeError(kind, resp.status_code, resp.text)
         resp.raise_for_status()
         return resp
 
@@ -355,14 +438,29 @@ class DeepSeekAdapter:
             "search_enabled": search_enabled,
             "preempt": False,
         }
-        with self._client.stream(
-            "POST", f"{BASE_URL}/api/v0/chat/completion",
-            json=body, headers=headers,
-        ) as resp:
+        resp = self._client.post(
+            f"{BASE_URL}/api/v0/chat/completion",
+            json=body, headers=headers, stream=True,
+        )
+        try:
+            kind = self._detect_waf_challenge(resp.status_code, resp.headers)
+            if kind:
+                # Drain so the connection can be reused.
+                try:
+                    body_text = resp.text
+                except Exception:
+                    body_text = ""
+                raise WAFChallengeError(kind, resp.status_code, body_text)
             resp.raise_for_status()
             frag_type = None  # None, 'thinking', 'content'
 
             for line in resp.iter_lines():
+                # curl_cffi yields bytes from iter_lines.
+                if isinstance(line, (bytes, bytearray)):
+                    try:
+                        line = line.decode("utf-8")
+                    except UnicodeDecodeError:
+                        continue
                 line = line.strip()
                 if not line:
                     continue
@@ -452,3 +550,8 @@ class DeepSeekAdapter:
                 if p == "response/status":
                     yield {"__type": "status", "status": v}
                     continue
+        finally:
+            try:
+                resp.close()
+            except Exception:
+                pass

--- a/adapter.py
+++ b/adapter.py
@@ -88,24 +88,71 @@ class DeepSeekAdapter:
     """Adapter for DeepSeek Chat API"""
 
     def __init__(self, token: str = TOKEN, cookies: str = COOKIES):
-        self.token = token
+        self.token = self._normalize_token(token)
         self.cookies = cookies
         self._solver = None
         self._client = httpx.Client(timeout=120)
         self._msg_counters: dict[str, int] = {}
+        # Header set captured from a live Chrome 149 session against
+        # chat.deepseek.com (frontend commit 1300ef9f7, captured 2026-06-19).
+        # Names use the same casing the real browser sends.
         self._base_headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Accept-Language": "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7",
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
+            "Authorization": f"Bearer {self.token}",
             "Cookie": cookies,
             "Origin": BASE_URL,
             "Referer": f"{BASE_URL}/",
-            "X-App-Version": "20241129.1",
+            "Priority": "u=1, i",
+            "Sec-Ch-Ua": (
+                '"Google Chrome";v="131", "Chromium";v="131", '
+                '"Not_A Brand";v="24"'
+            ),
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            # Application headers — values verified against the live frontend.
+            "X-App-Version": "2.0.0",
             "X-Client-Version": "2.0.0",
             "X-Client-Platform": "web",
             "X-Client-Locale": "zh_CN",
             "X-Client-Timezone-Offset": "28800",
+            "x-client-bundle-id": "com.deepseek.chat",
         }
+
+    @staticmethod
+    def _normalize_token(token: str) -> str:
+        """Accept either a bare token or DeepSeek's localStorage JSON wrapper.
+
+        DeepSeek stores its token in localStorage as
+            {"value":"<bare-token>","__version":"0"}
+        but the network layer sends only the bare value as
+            Authorization: Bearer <bare-token>
+        Users sometimes copy the localStorage form by mistake. Auto-unwrap
+        it so the adapter accepts either form.
+        """
+        if not token:
+            return token
+        s = token.strip()
+        if s.startswith("Bearer "):
+            s = s[len("Bearer "):].strip()
+        if s.startswith("{") and s.endswith("}"):
+            try:
+                obj = json.loads(s)
+                if isinstance(obj, dict) and "value" in obj and isinstance(obj["value"], str):
+                    return obj["value"]
+            except (ValueError, TypeError):
+                pass
+        return s
 
     @property
     def solver(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.100.0
 uvicorn>=0.20.0
 httpx>=0.24.0
+curl_cffi>=0.7.0
 wasmtime>=14.0.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
### Summary

Replace `httpx.Client` with `curl_cffi.Session(impersonate="chrome131")` so the JA3/JA4 fingerprint matches a real Chrome 131 build.

`chat.deepseek.com` runs Cloudflare and AWS WAF in front of an HWWAF + CW origin. All three layers read JA3/JA4 today, so a Python-`ssl` ClientHello is one rule away from a global block. `curl_cffi` wraps the `curl-impersonate` fork that emits a Chrome-identical ClientHello, HTTP/2 `SETTINGS`, and pseudo-header order.

### Independent verification

**TLS layer** — against `tls.peet.ws/api/all`:

```
JA4 = t13d1516h2_8daaf6152771_02713d6af862
Akamai HTTP/2 hash = 52d84b11737d980aef856699f885ca86
```

These hashes match a Chromium 131 build. Same request via `httpx` produces the well-known Python-stdlib JA4 that any commercial WAF flags as bot.

**Application layer** — against `chat.deepseek.com/api/v0/chat/create_pow_challenge`:

```
status: 200
server: CW                              # DeepSeek's own edge — request reached the origin
cf-mitigated: <absent>                  # Cloudflare did not challenge
x-amzn-waf-action: <absent>             # AWS WAF did not challenge
set-cookie: HWWAFSESTIME=...; HWWAFSESID=...
```

Note the HWWAF cookies. The origin's bot-management WAF actively issues us a session token, which it would not do for a flagged request — strong evidence we passed.

### Other changes (all in service of the new transport)

- **Cookie jar.** httpx had `Cookie:` baked into `_base_headers` as a static string, so any `Set-Cookie` rotation from the server (cf_clearance, AWS WAF tokens, HWWAFSESID) was silently dropped. Now seed the jar from the user's `DEEPSEEK_COOKIES` exactly once at construction, then let `curl_cffi` merge `Set-Cookie` across calls. Important: this also fixes a subtle long-running issue where DeepSeek's `cf_clearance` would expire before a heavily-used proxy noticed, since the static cookie blob was never refreshed.

- **`WAFChallengeError`.** New exception raised on the documented WAF challenges:
  - `405 + x-amzn-waf-action: captcha`
  - `202 + x-amzn-waf-action: challenge`
  - `403/429 + cf-mitigated: challenge`

  Previously these were misclassified as transient HTTP errors and the adapter would dutifully retry, deepening the suspicion. Now the request fails fast and the account pool can mark the account for manual recovery.

- **Per-account proxy.** New env `DEEPSEEK_PROXY_N` per account. Without this, multi-account deployments dial out from one IP, which is a textbook fingerprint. With this, each account can be pinned to a stable residential exit. Wired through `account_pool.Account.proxy → DeepSeekAdapter(proxy=...)`. Optional; backwards-compatible (no proxy = direct connection, same as today).

- **Inter-call jitter.** New env `DEEPSEEK_JITTER_SECS`. Sleeps a small uniform-random delay before each PoW challenge. Default `0.0` = current behavior. Setting `0.4` in production breaks the perfectly-periodic request timing that scripts otherwise have.

- **WASM path.** `open("sha3_wasm_bg.wasm")` depended on `cwd` and broke when the server is started from any directory other than the project root (systemd, Docker, etc.). Now uses `Path(__file__).parent / "sha3_wasm_bg.wasm"`. Backwards-compatible — running from project root still works.

### Verified end-to-end against `chat.deepseek.com` (with a real account, 2026-06-19)

```
/v1/models                         → 200
/v1/chat/completions  non-stream   → 200, content rendered, finish_reason=stop
/v1/chat/completions  stream       → 200, finish_reason=stop, [DONE] frame
/v1/messages          non-stream   → 200, stop_reason=end_turn
/v1/messages          stream       → 200, full event series intact
```

WAF-challenge detection paths tested with constructed responses (no live WAF challenge fortunately occurred during the smoke).

### New runtime dependency

Adds `curl_cffi>=0.7.0`. Wheels exist for cpython 3.10/3.11/3.12/3.13 and an abi3 wheel covers cpython 3.14+ (verified pip-installable on Python 3.14 via the `cp310-abi3` wheel).

Not lightweight (~25-40 MB on disk) but no background processes, no native daemons, behaves like a normal Python package. Optional uninstall is clean.

### Risk

Medium. This swaps the entire HTTP transport. The `chat_stream` path was the highest-risk piece (`curl_cffi`'s stream API differs from httpx's `with client.stream(...)` context manager) and is verified end-to-end against a real account.

If you'd rather not commit to `curl_cffi` as a hard dependency, I'm happy to refactor this into an optional transport that falls back to `httpx` when `curl_cffi` is missing. Let me know.