### PR TITLE
fix: stats 采样器读取不存在的 avg_latency_ms 属性，/admin/api/history 永远为空

### DIFF
--- a/stats_history.py
+++ b/stats_history.py
@@ -50,7 +50,7 @@ class StatsHistory:
                 stats.total_requests,
                 stats.success_requests,
                 stats.failed_requests,
-                float(stats.avg_latency_ms) if stats.avg_latency_ms > 0 else 0.0,
+                float(stats.total_latency_ms / stats.total_requests) if stats.total_requests > 0 else 0.0,
             ))
 
     def points(self) -> list[dict]:

--- a/tests/test_stats_history.py
+++ b/tests/test_stats_history.py
@@ -1,0 +1,59 @@
+"""Unit tests for stats_history."""
+from stats_history import StatsHistory
+
+
+class _FakeStats:
+    """Duck-typed stand-in matching admin.StatsSnapshot's real attributes."""
+
+    def __init__(self, total=0, success=0, failed=0, total_latency_ms=0.0):
+        self.total_requests = total
+        self.success_requests = success
+        self.failed_requests = failed
+        self.total_latency_ms = total_latency_ms
+
+
+def test_snapshot_records_points():
+    h = StatsHistory(max_points=3)
+    h.snapshot(_FakeStats(total=10, success=8, failed=2, total_latency_ms=5000.0))
+    pts = h.points()
+    assert len(pts) == 1
+    assert pts[0]["total"] == 10
+    assert pts[0]["success"] == 8
+    assert pts[0]["failed"] == 2
+    assert pts[0]["avg_latency_ms"] == 500.0
+
+
+def test_snapshot_zero_requests_does_not_raise():
+    h = StatsHistory()
+    h.snapshot(_FakeStats())
+    p = h.points()[0]
+    assert p["total"] == 0
+    assert p["avg_latency_ms"] == 0.0
+
+
+def test_snapshot_never_reads_nonexistent_attrs():
+    """Regression: snapshot() must only touch attributes that exist on
+    admin.StatsSnapshot — a stray AttributeError is silently swallowed by
+    the sampler loop, leaving /admin/api/history empty forever."""
+    h = StatsHistory()
+
+    class _Strict:
+        def __getattr__(self, name):
+            raise AssertionError(f"snapshot() accessed unknown attribute: {name}")
+
+    s = _Strict()
+    s.total_requests = 4
+    s.success_requests = 3
+    s.failed_requests = 1
+    s.total_latency_ms = 1000.0
+    h.snapshot(s)
+    assert h.points()[0]["avg_latency_ms"] == 250.0
+
+
+def test_points_bounded_by_maxlen():
+    h = StatsHistory(max_points=2)
+    for i in range(5):
+        h.snapshot(_FakeStats(total=i))
+    pts = h.points()
+    assert len(pts) == 2
+    assert [p["total"] for p in pts] == [3, 4]


### PR DESCRIPTION
## 问题描述

v3 WebUI 仪表盘的「请求趋势」图表永远没有数据：`/admin/api/stats` 的实时计数正常，但 `/admin/api/history` 自进程启动起始终返回 `points: []`。

## 根因

`stats_history.StatsHistory.snapshot()` 访问 `stats.avg_latency_ms`：

```python
float(stats.avg_latency_ms) if stats.avg_latency_ms > 0 else 0.0,
```

但 `admin.StatsSnapshot` 上并不存在 `avg_latency_ms` 属性（只有 `total_latency_ms`，`/admin/api/stats` 端点是自行计算的：`admin.py` 中 `int(s.total_latency_ms / s.total_requests) if s.total_requests > 0 else 0`）。

于是每次快照都抛出 `AttributeError`，而采样线程的 `except Exception: pass` 会静默吞掉异常（包括首次快照），导致 60 个点一个也写不进去，图表永远空白。

## 修复

与 stats 端点保持一致，改为自算平均值：

```python
float(stats.total_latency_ms / stats.total_requests) if stats.total_requests > 0 else 0.0,
```

## 测试

- 新增 `tests/test_stats_history.py`（4 个用例）：正常快照取值、零请求不除零、**严格对象回归测试**（`__getattr__` 对未知属性抛 AssertionError，确保 snapshot 只触碰 StatsSnapshot 真实存在的字段）、`max_points` 截断。
- 本地 `pytest tests/test_stats_history.py -v`：4 passed。

## 实际验证

在生产环境（CentOS 7 / Python 3.10）打了此补丁后：修复前 `/admin/api/history` 返回 `"points": []`（进程已运行 30+ 小时、951 次请求）；修复并重启后数据点正常累积：

```json
{"t": 1788514906, "total": 2, "success": 2, "failed": 0, "avg_latency_ms": 1867.01}
```

WebUI 请求趋势图恢复正常渲染。